### PR TITLE
[feat/#2,3] 백엔드에게 바이너리 데이터 받아서 활용하기, useJinary 커스텀 훅 제작

### DIFF
--- a/jinary-front/src/App.jsx
+++ b/jinary-front/src/App.jsx
@@ -6,7 +6,7 @@ const BACKEND_URL = import.meta.env.VITE_BACKEND_URL || 'http://localhost:8080';
 function formatBytes(bytes) {
   if (bytes === 0) return '0 Bytes';
   const k = 1024;
-  const sizes = ['Bytes', 'KB', 'MB'];
+  const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
   // Math.log()로 단위를 결정합니다
   // 예: 1500 → log(1500)/log(1024) ≈ 1.05 → floor → 1 → "KB"
   const i = Math.floor(Math.log(bytes) / Math.log(k));

--- a/jinary-front/src/App.jsx
+++ b/jinary-front/src/App.jsx
@@ -1,31 +1,8 @@
 import React, { useState } from 'react';
-// ─── Protobuf 번들에서 인코딩/디코딩 함수를 가져옵니다 ───
-// encodeUserList: JS 객체 → Uint8Array(바이너리)로 변환
-// decodeUserList: Uint8Array(바이너리) → JS 객체로 복원
-import { encodeUserList, decodeUserList } from './proto/user_proto_bundle.js';
+import { decodeUserList } from './proto/user_proto_bundle.js';
 
-// ──────────────────────────────────────────────────────────
-// 샘플 유저 데이터를 생성하는 함수
-// ──────────────────────────────────────────────────────────
-// count 만큼의 가짜 유저 데이터를 배열로 만들어 반환합니다.
-// 데이터 양을 조절하면서 JSON vs Protobuf 크기 차이를 비교할 수 있습니다.
-function generateSampleUsers(count) {
-  const users = [];
-  for (let i = 1; i <= count; i++) {
-    users.push({
-      id: `user-${String(i).padStart(4, '0')}`,
-      name: `테스트유저_${i}`,
-      email: `user${i}@jinary.dev`,
-      age: 20 + (i % 40), // 20~59 사이의 나이
-    });
-  }
-  return users;
-}
+const BACKEND_URL = import.meta.env.VITE_BACKEND_URL || 'http://localhost:8080';
 
-// ──────────────────────────────────────────────────────────
-// 바이트 수를 사람이 읽기 쉬운 단위로 변환하는 유틸 함수
-// ──────────────────────────────────────────────────────────
-// 예: 1024 → "1.00 KB", 1048576 → "1.00 MB"
 function formatBytes(bytes) {
   if (bytes === 0) return '0 Bytes';
   const k = 1024;
@@ -37,62 +14,56 @@ function formatBytes(bytes) {
 }
 
 function App() {
-  // ─── React 상태(State) 정의 ─────────────────────────────
-  // userCount: 생성할 유저 수 (슬라이더로 조절)
-  const [userCount, setUserCount] = useState(100);
-  // result: 인코딩/디코딩 결과를 담는 객체
   const [result, setResult] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
 
-  // ──────────────────────────────────────────────────────────
-  // 핵심 함수: JSON vs Protobuf 비교 실행
-  // ──────────────────────────────────────────────────────────
-  const runComparison = () => {
-    // 1) 샘플 데이터 생성
-    const users = generateSampleUsers(userCount);
+  const fetchAndDecode = async () => {
+    setLoading(true);
+    setError(null);
 
-    // ─── JSON 직렬화 ───────────────────────────────────────
-    // JSON.stringify(): JS 객체 → JSON 문자열로 변환
-    // TextEncoder: 문자열 → UTF-8 바이트 배열(Uint8Array)로 변환
-    // → 이렇게 해야 실제 네트워크로 전송될 때의 바이트 크기를 정확히 측정할 수 있습니다.
-    const jsonString = JSON.stringify({ users });
-    const jsonBytes = new TextEncoder().encode(jsonString);
-    const jsonSize = jsonBytes.byteLength; // JSON의 실제 바이트 크기
+    try {
+      const response = await fetch(`${BACKEND_URL}`, {
+        headers: { Accept: 'application/x-protobuf' },
+      });
 
-    // ─── Protobuf 인코딩 ──────────────────────────────────
-    // encodeUserList(): { users: [...] } 객체를 바이너리(Uint8Array)로 변환
-    // Protobuf는 필드 이름 대신 "필드 번호"를 사용하고,
-    // 숫자를 가변 길이 인코딩(Varint)으로 압축하기 때문에
-    // JSON보다 훨씬 작은 크기로 동일한 데이터를 표현합니다.
-    const protobufBinary = encodeUserList({ users });
-    const protobufSize = protobufBinary.byteLength; // Protobuf의 실제 바이트 크기
+      if (!response.ok) {
+        throw new Error(
+          `서버 응답 오류: ${response.status} ${response.statusText}`,
+        );
+      }
 
-    // ─── Protobuf 디코딩 (검증용) ─────────────────────────
-    // 인코딩한 바이너리를 다시 디코딩해서 원본 데이터와 같은지 확인합니다.
-    // 이것이 실제로 백엔드에서 받은 바이너리를 프론트에서 복원하는 과정과 동일합니다.
-    const decoded = decodeUserList(protobufBinary);
+      // 응답을 ArrayBuffer로 변환 → Uint8Array로 감싸기
+      const arrayBuffer = await response.arrayBuffer();
+      const binaryData = new Uint8Array(arrayBuffer);
+      const protobufSize = binaryData.byteLength;
 
-    // ─── 결과 저장 ────────────────────────────────────────
-    // 절감률 계산: (JSON 크기 - Protobuf 크기) / JSON 크기 × 100
-    const savedPercent = ((1 - protobufSize / jsonSize) * 100).toFixed(1);
+      // Protobuf 바이너리 → JS 객체로 디코딩
+      const decoded = decodeUserList(binaryData);
 
-    setResult({
-      userCount,
-      jsonSize,
-      protobufSize,
-      savedPercent,
-      // 디코딩 결과에서 처음 3개 유저만 미리보기로 보여줍니다.
-      decodedPreview: decoded.users.slice(0, 3),
-      // 인코딩된 바이너리의 처음 50바이트를 16진수로 보여줍니다.
-      // 이렇게 하면 실제로 바이너리 데이터가 어떻게 생겼는지 눈으로 확인할 수 있어요.
-      rawHex: Array.from(protobufBinary.slice(0, 50))
-        .map((b) => b.toString(16).padStart(2, '0'))
-        .join(' '),
-    });
+      // 같은 데이터를 JSON으로 직렬화했을 때의 크기 비교
+      const jsonSize = new TextEncoder().encode(
+        JSON.stringify(decoded),
+      ).byteLength;
+      const savedPercent = ((1 - protobufSize / jsonSize) * 100).toFixed(1);
+
+      setResult({
+        userCount: decoded.users.length,
+        jsonSize,
+        protobufSize,
+        savedPercent,
+        decodedPreview: decoded.users.slice(0, 3),
+        rawHex: Array.from(binaryData.slice(0, 50))
+          .map((b) => b.toString(16).padStart(2, '0'))
+          .join(' '),
+      });
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
   };
 
-  // ──────────────────────────────────────────────────────────
-  // 화면 렌더링 (JSX)
-  // ──────────────────────────────────────────────────────────
   return (
     <div
       style={{
@@ -102,77 +73,46 @@ function App() {
         margin: '0 auto',
       }}
     >
-      {/* ─── 헤더 영역 ─── */}
       <h1 style={{ fontSize: '28px', marginBottom: '8px' }}>
         Jinary PoC - 바이너리 통신 데모
       </h1>
       <p style={{ color: '#666', marginBottom: '32px' }}>
-        백엔드 없이 프론트엔드에서 JSON vs Protobuf 크기를 직접 비교합니다.
+        백엔드({BACKEND_URL})에서 Protobuf 바이너리를 받아 디코딩합니다.
       </p>
 
-      <div
-        style={{
-          background: '#f8f9fa',
-          padding: '24px',
-          borderRadius: '12px',
-          marginBottom: '24px',
-          border: '1px solid #e0e0e0',
-        }}
-      >
-        <label
-          style={{
-            fontSize: '16px',
-            fontWeight: 'bold',
-            display: 'block',
-            marginBottom: '12px',
-          }}
-        >
-          생성할 유저 수:{' '}
-          <span style={{ color: '#aa3bff' }}>{userCount}명</span>
-        </label>
-
-        <input
-          type="range"
-          min="10"
-          max="5000"
-          step="10"
-          value={userCount}
-          onChange={(e) => setUserCount(Number(e.target.value))}
-          style={{ width: '100%', cursor: 'pointer' }}
-        />
-
-        {/* 슬라이더 아래에 범위 표시 */}
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            fontSize: '12px',
-            color: '#999',
-          }}
-        >
-          <span>10명</span>
-          <span>5,000명</span>
-        </div>
-      </div>
-
-      {/* ─── 비교 실행 버튼 ─── */}
       <button
-        onClick={runComparison}
+        onClick={fetchAndDecode}
+        disabled={loading}
         style={{
           padding: '14px 32px',
           fontSize: '16px',
-          cursor: 'pointer',
-          background: '#aa3bff',
+          cursor: loading ? 'wait' : 'pointer',
+          background: loading ? '#ccc' : '#aa3bff',
           color: 'white',
           border: 'none',
           borderRadius: '8px',
           fontWeight: 'bold',
           width: '100%',
-          marginBottom: '32px',
+          marginBottom: '24px',
         }}
       >
-        JSON vs Protobuf 비교 실행
+        {loading ? '요청 중...' : '백엔드에서 바이너리 데이터 받기'}
       </button>
+
+      {error && (
+        <div
+          style={{
+            padding: '16px',
+            borderRadius: '8px',
+            background: '#fff5f5',
+            border: '1px solid #ff6b6b',
+            color: '#c92a2a',
+            marginBottom: '24px',
+          }}
+        >
+          {error}
+        </div>
+      )}
       {result && (
         <div>
           <div style={{ display: 'flex', gap: '16px', marginBottom: '24px' }}>
@@ -336,7 +276,7 @@ function App() {
               </div>
             ))}
             <div style={{ fontSize: '12px', color: '#999', marginTop: '8px' }}>
-              바이너리 → 디코딩 → JS 객체 복원 성공
+              백엔드 바이너리 → Protobuf 디코딩 → JS 객체 복원 성공
             </div>
           </div>
         </div>

--- a/jinary-front/src/hook/useJinary.ts
+++ b/jinary-front/src/hook/useJinary.ts
@@ -1,0 +1,59 @@
+import { useState, useCallback } from 'react';
+
+// decodeFunction은 외부에서 주입받도록 설계하여 확장성을 높임
+export const useJinary = (url, decodeFunction) => {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  // 성능 측정을 위한 메타데이터 상태
+  const [meta, setMeta] = useState({
+    protobufSize: 0,
+    jsonSize: 0,
+    rawHex: '',
+  });
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch(url, {
+        headers: { Accept: 'application/x-protobuf' },
+      });
+
+      if (!response.ok) {
+        throw new Error(
+          `서버 응답 오류: ${response.status} ${response.statusText}`,
+        );
+      }
+
+      const arrayBuffer = await response.arrayBuffer();
+      const binaryData = new Uint8Array(arrayBuffer);
+      const protobufSize = binaryData.byteLength;
+
+      // 주입받은 디코딩 함수 실행
+      const decoded = decodeFunction(binaryData);
+
+      // JSON 크기 비교 로직 (메타데이터용)
+      const jsonSize = new TextEncoder().encode(
+        JSON.stringify(decoded),
+      ).byteLength;
+
+      setData(decoded);
+      setMeta({
+        protobufSize,
+        jsonSize,
+        rawHex: Array.from(binaryData.slice(0, 50))
+          .map((b) => b.toString(16).padStart(2, '0'))
+          .join(' '),
+      });
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [url, decodeFunction]);
+
+  // 반환값: UI에 필요한 모든 상태와 fetch 함수
+  return { data, loading, error, meta, fetchData };
+};


### PR DESCRIPTION
현재 백엔드에게 바이너리 데이터를 받아서, proto데이터로 만들고 JSON 데이터로 받았을 때와의 데이터 크기 차이를 뷰로 볼 수 있게 구현을 하였습니다. 

데이터 요청
- VITE_BACKEND_URL (없으면 http://localhost:8080)로 요청합니다.
- Accept: application/x-protobuf로 헤더를 설정합니다. 당연히 protobuf 데이터를 받기 때문에 선언해주는게 좋습니다.
<br>

디코딩
- 응답을 arrayBuffer()로 받고 Uint8Array 변환합니다. 
- decodeUserList로 JS 객체 변환시킵니다.
  - **과정을 정리해보면 백엔드가 Protobuf 바이너리를 응답으로 보냄
프론트가 arrayBuffer()로 그 원시 바이트를 받음
Uint8Array로 디코더가 읽기 좋은 바이트 배열 형태로 감쌈
decodeUserList로 JS 객체로 복원
그 객체를 화면에 사용하거나 크기 비교 계산에 사용**
<br>

성능 지표 계산
- protobufSize vs JSON.stringify(decoded)의 jsonSize 비교합니다.
- 절감률 % 계산 (savedPercent) - 얼마나 절감되었나 값을 보여줍니다. 
<br>

UI
- JSON/Protobuf 크기 카드를 눈으로 볼 수 있게 합니다. 뷰는 제가 짰고 현재 데이터를 주고받는 로직은 ai를 활용하였습니다.
<br>

상태 관리
- loading, error, result 3개 state로 처리했습니다. 