### PR TITLE
[feat/#8-mySelf] Jinary 코어 강화(.create)

### DIFF
--- a/jinary-front/README.md
+++ b/jinary-front/README.md
@@ -33,3 +33,48 @@ Node.js에게 protobufjs 패키지 안에 있는 pbjs라는 번역기(변환 도
 ```
 npm run proto:gen
 ```
+
+---
+
+# 다음 작업: 코어 API 확장
+
+현재 `core/jinary.ts`에는 `jinary.get()` 하나만 존재합니다.
+axios처럼 범용적으로 사용할 수 있도록 코어 API를 확장해야 합니다.
+
+## 구현 목표
+
+### 1. `jinary.create(config)` — 인스턴스 생성
+- baseURL, 공통 헤더, timeout 등 설정을 담는 인스턴스를 생성
+- 매 요청마다 전체 URL을 쓰지 않고, 상대 경로만으로 요청 가능
+
+```typescript
+const client = jinary.create({
+  baseURL: 'https://api.example.com',
+  timeout: 5000,
+  headers: { Authorization: 'Bearer token' }
+});
+
+client.get('/users', decodeFunction);
+```
+
+### 2. POST 메서드 추가
+- 바이너리 데이터를 서버로 보내는 것도 지원
+
+```typescript
+client.post('/users', bodyData, decodeFunction);
+```
+
+### 3. 요청 옵션 확장
+- timeout: 요청 제한 시간
+- headers: 요청별 커스텀 헤더
+- 기타 필요한 설정 추가
+
+## 현재 구조
+
+```
+src/
+├── core/
+│   └── jinary.ts       ← 여기를 확장
+├── hook/
+│   └── useJinary.ts    ← 코어를 감싸는 React 래퍼 (코어 확장 후 연동)
+```

--- a/jinary-front/src/core/jinary.ts
+++ b/jinary-front/src/core/jinary.ts
@@ -9,6 +9,60 @@ interface JinaryResponse<T> {
     meta: JinaryMeta;
 }
 
+interface JinaryConfig {
+    baseURL: string;
+    timeout?: number;
+    headers?: Record<string, string>;
+}
+
+function create(config: JinaryConfig) {                                                                            
+    return {                                                                                                     
+        get: async <T>(url: string, decodeFunction: (binary: Uint8Array) => T): Promise<JinaryResponse<T>> => {                                                                  
+            const fullURL = config.baseURL + url;
+            const controller = new AbortController();
+            let timeoutId: number | undefined;
+            if (config.timeout) {
+                timeoutId = setTimeout(() => controller.abort(), config.timeout);
+            }
+            const mergedHeaders = {                                                                                
+                Accept: 'application/x-protobuf',                                                                  
+                ...config.headers,                                                                               
+            };
+            const response = await fetch(fullURL, {
+                headers: mergedHeaders,
+                signal: controller.signal,
+            });                      
+            if(timeoutId) clearTimeout(timeoutId);                                                                               
+            if (!response.ok) {                                                                                                
+                throw new Error(
+                    `서버 응답 오류: ${response.status} ${response.statusText}`,                                               
+                );                                                                                                           
+            }
+
+            const arrayBuffer = await response.arrayBuffer();                                                                  
+            const binaryData = new Uint8Array(arrayBuffer);
+            const protobufSize = binaryData.byteLength;                                                                        
+
+            const decoded = decodeFunction(binaryData);
+
+            const jsonSize = new TextEncoder().encode(
+                JSON.stringify(decoded),
+            ).byteLength;                                                                                                      
+
+            return {                                                                                                           
+                data: decoded,                                                                                               
+                meta: {
+                    protobufSize,
+                    jsonSize,
+                    rawHex: Array.from(binaryData.slice(0, 50))
+                        .map((b) => b.toString(16).padStart(2, '0'))
+                        .join(' '),                                                                                            
+                },
+            };
+        }                                                                                                          
+    }                                                                                                            
+} 
+
 async function get<T>(
     url: string,
     decodeFunction: (binary: Uint8Array) => T
@@ -47,5 +101,5 @@ async function get<T>(
       };
   } 
 
-export const jinary = { get };
+export const jinary = { create, get };
 export type { JinaryMeta, JinaryResponse };


### PR DESCRIPTION
**코어 API 확장 - `jinary.create(config)` 구현**                                                                   
                                                                                                                     
  기존 `jinary.get(url, decodeFunction)` 만 존재하던 코어에, axios처럼 인스턴스를 생성할 수 있는 `jinary.create()`   
  함수를 추가했습니다.                                                          
                                                                                                                     
  ### 구현 사항
  - `JinaryConfig` 인터페이스 정의 (baseURL, timeout, headers)                                                       
  - `jinary.create(config)` — baseURL 기반 인스턴스 생성                                                           
  - URL 자동 조합 (`config.baseURL + url`)                                                                           
  - 공통 헤더 병합 (기본 protobuf 헤더 + 사용자 설정 헤더)                                                         
  - `AbortController` 기반 timeout 처리                                         
                                                                                                                     
  ### 사용 예시                                                                                                      
  ```typescript                                                                                                      
  const client = jinary.create({                                                                                     
    baseURL: 'http://localhost:8080',                                                                                
    timeout: 5000,                                                                                                   
    headers: { Authorization: 'Bearer token' }                                                                       
  });                                                                                                              
  client.get('/users', decodeFunction);
  ```

  ### jinary.get() vs jinary.create().get() 비교

  create 없이 (지금도 가능)                                                    
                                                                                
  jinary.get('http://localhost:8080/users', decodeFunction)                    
  jinary.get('http://localhost:8080/products', decodeFunction)                  
  jinary.get('http://localhost:8080/orders', decodeFunction)                                                                                                                              
                                                                               
  매번 전체 URL 반복, 헤더나 timeout 설정도 매번 넘겨야 해요.                                                                                                                             
                                                                                                                                                                                          
  create 사용                                                                                                                                                                             
                                                                                                                                                                                          
  const client = jinary.create({                                                                                                                                                          
    baseURL: 'http://localhost:8080',                                                                                                                                                     
    timeout: 5000,                                                                                                                                                                        
    headers: { Authorization: 'Bearer token' }                                                                                                                                          
  });                                   

  client.get('/users', decodeFunction)                                                                                                                                                    
  client.get('/products', decodeFunction)                                       
  client.get('/orders', decodeFunction)                                                                                                                                                   
                                                                                                                                                                                        
  설정을 한 번만 하면 모든 요청에 자동 적용돼요.                                                                                                                                          
                                                                                
  실제로 axios도 이렇게 씁니다                                                                                                                                                            
                                                                                                                                                                                        
  // axios도 두 가지 방식 모두 지원                                                                                                                                                       
  axios.get('http://localhost:8080/users')           // 직접 호출              
  const api = axios.create({ baseURL: '...' })       // 인스턴스                                                                                                                          
  api.get('/users')

  ### 앞으로 남은 작업은 
- POST 메서드 추가 (바이너리 데이터를 서버로)
- decodeFunction없이 백엔드와 스키마 자동 협상 (백엔드와 협의를 해야함)
- npm 패키지 배포!
- Protobuf가 JSON보다 데이터 크기는 작아지는건 무조건 확정입니다. 근데 Protobuf decode 과정이 JSON.parse보다 무거울 수 있습니다. 따라서 크기 절감과 decode 오버헤드를 합쳐서 총 소요 시간이 작은지 확인해야합니다. (전송 속도, 네트워크에서 실제로 더 빠른가? 파싱 속도, decode 시간 vs JSON.parse 시간?, 대용량에서의 차이, 데이터가 커질수록 차이가 벌어지는가?)
백엔드에서 엔드포인트를 하나 추가해 그냥 json 값으로 보내도록 요청을 할 예정입니다. 또한 데이터를 더 크게 전달하도록 또한 요청 하겠습니다.



closes #11 
