### PR TITLE
[feat/#9,10,11-mySelf(11은 withAI)] 백엔드 UserPayload용 .proto 정의 및 JS 번들 생성, core/jinary.ts에 post() 추가, 바이너리 전송 지원, App.jsx round-trip POST 데모 추가 + GET 엔드포인트 마이그레이션

### DIFF
--- a/jinary-front/docs/front-jinaryPost.md
+++ b/jinary-front/docs/front-jinaryPost.md
@@ -1,0 +1,212 @@
+# front-jinaryPost — 개발 로그
+
+> 작업 기간: 2026.05.03 — 05.04
+> 브랜치: `front-jinaryPost`
+> 배경: 백엔드 정상화 형이 `@Jinary` 어노테이션 PR(#13)을 머지한 직후 시작.
+> 프론트에서 바이너리 POST가 가능한지, 그리고 백엔드의 어노테이션이
+> 의도대로 동작하는지를 양쪽에서 검증하는 게 이번 브랜치의 목표.
+
+---
+
+## 1. 들어가기 전 — 무엇을 증명하고 싶었나
+
+지금까지의 데모는 "백엔드 → 프론트" 한 방향뿐이었다. 양방향이 되어야
+"바이너리 통신 라이브러리"라고 부를 수 있고, 백엔드의 `@Jinary`가 정말
+**자바 객체처럼 받지만 와이어는 바이너리**인지를 눈으로 검증해야
+다음 단계(자동 스키마 협상)로 갈 명분이 생긴다.
+
+발표 관점에서도, 그래프 한 축을 더 그릴 수 있게 된다 — 지금까지는
+**다운로드** 절감률만 보여줬는데, **업로드** 방향까지 측정할 수 있게 됨.
+
+## 2. 첫 갈래 — 빠른 round-trip vs 진짜 인코더
+
+처음 떠오른 두 가지 길:
+
+| 옵션 | 작업량 | 결과 |
+|---|---|---|
+| (A) round-trip 검증 | 작음 | GET 응답 바이너리를 그대로 POST로 되쏘기. 백엔드 검증용 |
+| (B) 진짜 인코더 | 큼 | JS 객체 → 바이너리 변환 자체를 프론트가 수행 |
+
+처음엔 (A)가 빨라서 끌렸지만, 결국 (A)는 **버려질 코드**다. 프론트 입장에선
+검증 도구일 뿐이고 라이브러리가 갖춰야 할 인코더는 어차피 만들어야 한다.
+(B)로 가기로 결정.
+
+## 3. 백엔드 와이어 포맷 확인
+
+(B)로 가려면 백엔드가 어떤 포맷으로 직렬화하는지부터 알아야 한다.
+`Jinary-Backend/.../jinary/JinaryCodec.java`와 `JinarySchemaGenerator.java`를
+한 번 훑었다.
+
+핵심 발견:
+- `DynamicMessage.toByteArray()` — **표준 protobuf**.
+- 스키마는 `JinarySchemaGenerator`가 자바 클래스 reflection으로 자동 생성.
+- 필드 번호는 자바 record 선언 순서대로 1, 2, 3...
+
+→ 즉 프론트 인코더는 **표준 protobuf 인코더면 충분**. 이미 깔려있는
+`protobufjs`로 바로 갈 수 있다는 결론. 별도 라이브러리 도입 불필요.
+
+> ⚠️ 알아둘 함정: 백엔드가 record 필드 순서를 바꾸면 와이어가 깨진다.
+> 이건 향후 백엔드 SDK가 풀어야 할 숙제. 일단은 양쪽이 약속으로 유지.
+
+## 4. Step 1 — `UserPayload.proto` + 번들 생성
+
+백엔드 자동 생성 스키마와 1:1 매칭되는 .proto 파일을 손으로 정의:
+
+```proto
+syntax = "proto3";
+
+message UserPayload {
+  int32  id    = 1;
+  string name  = 2;
+  string email = 3;
+}
+```
+
+기존 `proto:gen` 스크립트 컨벤션을 따라 `package.json`에
+`proto:gen:payload` 한 줄 추가:
+
+```json
+"proto:gen:payload": "npx pbjs --es6 src/proto/user_payload.js src/proto/user_payload.proto"
+```
+
+### 함정 — 첫 import 실패
+
+처음에 `import { UserPayload } from '...'` 으로 가져오려다 export 이름
+mismatch로 실패. 생성된 번들 파일을 직접 열어봤더니 클래스 형태가 아니라
+standalone 함수로 export 되어 있었다:
+
+```js
+export function encodeUserPayload(message) { ... }
+export function decodeUserPayload(binary)  { ... }
+```
+
+→ 결국 import 이름 정정. **생성기가 만든 파일이라도 한 번씩은 열어봐야
+한다는 교훈**.
+
+## 5. Step 2 — `core/jinary.ts`에 `post()` 추가
+
+기존 `get()`과 대칭 구조로 작성. 헤더 두 개가 핵심:
+- `Content-Type: application/x-jinary` — 백엔드 `JinaryMediaTypes.APPLICATION_JINARY`와 매칭
+- `Accept: application/json` — `jsonFromBinary` 엔드포인트의 `produces`
+
+```ts
+async function post<T>(
+    url: string,
+    binary: Uint8Array,
+): Promise<JinaryResponse<T>> {
+    const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/x-jinary',
+            Accept: 'application/json',
+        },
+        body: binary as BodyInit,
+    });
+    if (!response.ok) {
+        throw new Error(`서버 응답 오류: ${response.status} ${response.statusText}`);
+    }
+    const json = (await response.json()) as T;
+
+    const protobufSize = binary.byteLength;
+    const jsonSize = new TextEncoder().encode(JSON.stringify(json)).byteLength;
+
+    return {
+        data: json,
+        meta: {
+            protobufSize,
+            jsonSize,
+            rawHex: Array.from(binary.slice(0, 50))
+                .map((b) => b.toString(16).padStart(2, '0'))
+                .join(' '),
+        },
+    };
+}
+```
+
+`meta.protobufSize`는 우리가 보낸 바이너리, `meta.jsonSize`는 같은
+데이터를 JSON으로 보냈을 때의 크기 — 발표용 절감률 계산에 그대로 사용 가능.
+
+### TS 5.7 타입 마찰
+
+`body: binary` 한 줄에서 컴파일 에러. TS 5.7부터 `Uint8Array`가 generic
+(`Uint8Array<ArrayBufferLike>`)으로 바뀌면서 DOM의 `BodyInit`과 좁은
+의미에서 맞지 않게 됨. 런타임에선 정상이라 `as BodyInit` 캐스트로 우회.
+대안으로 `new Blob([binary])` 도 가능하지만 굳이 한 단계 더 거칠 이유는 없다.
+
+## 6. Step 3 — App.jsx 통합 + GET 엔드포인트 마이그레이션
+
+원래는 POST 데모만 추가할 계획이었는데, 백엔드의 `/test/binary`
+응답이 `UserList`에서 단일 `UserPayload`로 바뀐 걸 깜빡 — 기존 GET
+데모가 이미 깨져있었다. 이 브랜치에서 같이 정리하기로 결정.
+
+### 변경 사항 요약
+
+1. **import 정리**
+   - `decodeUserList` (기존 `user_proto_bundle.js`) 제거
+   - `encodeUserPayload`, `decodeUserPayload` 추가
+   - `useState`, `jinary` (코어 직접 사용) 추가
+
+2. **GET 호출 마이그레이션**
+   ```diff
+   - useJinary(BACKEND_URL, decodeUserList)
+   + useJinary(BACKEND_URL + '/test/binary', decodeUserPayload)
+   ```
+
+3. **렌더링 부분 — `data.users[*]` → 단일 객체**
+   - `{data.users.length}명 기준` → `단일 객체 기준`
+   - `data.users.slice(0,3).map(...)` → 단일 user 표시
+
+4. **POST 데모 영역 신설** — 별도 카드 컴포넌트로 분리.
+   ```js
+   const binary = encodeUserPayload(payload);
+   const result = await jinary.post(URL, binary);
+   ```
+   `보낸 객체`와 `백엔드가 돌려준 JSON`을 나란히 표시 → 무손실 round-trip을
+   눈으로 확인할 수 있도록.
+
+## 7. 디버깅 일지
+
+도중에 막혔던 지점들. 각각 짧게.
+
+### 406 Not Acceptable
+
+GET 버튼 누르자마자 406. 코어 `get()`의 `Accept` 헤더가 옛날
+`application/x-protobuf`로 박혀있던 게 원인. 백엔드 새 엔드포인트는
+`produces = "application/x-jinary"`라서 거절한 것. 헤더 한 줄 교체로 해결.
+
+### .env 마이그레이션
+
+기존 `VITE_BACKEND_URL`이 도메인 + path까지 다 박혀있었음
+(`https://jinary.duckdns.org/test/binary`). 백엔드 도메인 비용이
+나가서 로컬로 회귀하면서 URL 구조도 origin만 남기고 코드 쪽에서
+path를 붙이도록 정리:
+
+```diff
+- VITE_BACKEND_URL=https://jinary.duckdns.org/test/binary
++ VITE_BACKEND_URL=http://localhost:8080
+```
+
+부수 효과로 GET 버튼이 잠깐 404 → useJinary 호출에 path 붙여서 해결.
+`.env` 변경은 dev 서버 재시작 필요한 점에서 한 번 헷갈렸음.
+
+### 트래킹된 `.DS_Store` 충돌
+
+`git pull` 시 로컬 `.DS_Store`가 수정되어 있어서 충돌. 트래킹된 채로
+유지되고 있는 게 근본 원인. `git checkout -- .DS_Store`로 우선 통과.
+백엔드 폴더 쪽 `.DS_Store`까지 같이 정리하려면 백엔드 형이랑 합의 필요.
+
+## 8. 결과
+
+- ✅ 양방향 바이너리 통신 동작 (GET/POST 모두 정상)
+- ✅ 백엔드 `@Jinary` 자동 디코딩 검증 — 보낸 객체와 받은 JSON 일치
+- ✅ 업로드 방향 사이즈 비교까지 데모에 포함
+- ✅ 프론트 인코더 흐름 확보 — 다음 작업(자동 스키마 협상)의 기반
+
+## 9. 남은 것 / 다음 브랜치 후보
+
+- 인코더가 아직 손으로 .proto를 들고 있다 → **자동 스키마 협상** (M06)
+- `useJinary` 훅이 GET만 지원 → **POST용 mutation 훅** 신설
+- 코어/훅을 별도 패키지로 분리해서 npm 배포 준비 (M08)
+
+발표 자료(중간 발표 v15장 deck)에서는 Roadmap 슬라이드의 M05~M08이
+이번 브랜치 이후 작업과 대응. 다음 마일스톤 정의 시 본 로그 참고.

--- a/jinary-front/package.json
+++ b/jinary-front/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "proto:gen": "npx pbjs --es6 src/proto/user_proto_bundle.js src/proto/user_proto_bundle.proto",
+    "proto:gen:payload": "npx pbjs --es6 src/proto/user_payload.js src/proto/user_payload.proto",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/jinary-front/src/App.jsx
+++ b/jinary-front/src/App.jsx
@@ -1,6 +1,7 @@
-import React from 'react';                                                                                         
-import { useJinary } from './hook/useJinary';                                                                      
-import { decodeUserList } from './proto/user_proto_bundle.js';
+import React, { useState } from 'react';                 
+import { jinary } from './core/jinary';
+import { useJinary } from './hook/useJinary';
+import { encodeUserPayload, decodeUserPayload } from './proto/user_payload.js';
 const BACKEND_URL = import.meta.env.VITE_BACKEND_URL || 'http://localhost:8080';
 
 function formatBytes(bytes) {
@@ -14,11 +15,42 @@ function formatBytes(bytes) {
 }
 
 function App() {
-  const { data, loading, error, meta, fetchData } = useJinary(                                                       
-    BACKEND_URL,  
-    decodeUserList
+  const { data, loading, error, meta, fetchData } = useJinary(
+    BACKEND_URL + '/test/binary',
+    decodeUserPayload,
   );
+  const [postResult, setPostResult]   = useState(null);                                                                                                                                 
+  const [postError,  setPostError]    = useState(null);                                                                                                                                 
+  const [postLoading, setPostLoading] = useState(false); 
 
+  async function handlePostTest() {                                                                                                                                                   
+    setPostLoading(true);                                                                                                                                                               
+    setPostError(null);                                                                                                                                                               
+    try {                                                                                                                                                                               
+      // 1) JS 객체                                                                                                                                                                   
+      const payload = {                                                                                                                                                                 
+        id: 202417051,                                                                                                                                                                
+        name: 'Sanghwa',                    
+        email: 'test@skhu.ac.kr',                                                                                                                                                       
+      };                                
+
+      // 2) 바이너리 인코딩                                                                                                                                                             
+      const binary = encodeUserPayload(payload);                                                                                                                             
+
+      // 3) 바이너리 POST → JSON 응답                                                                                                                                                   
+      const result = await jinary.post(                                                                                                                                               
+        BACKEND_URL + '/test/json-from-binary',                                                                                                                                         
+        binary,                                                                                                                                                                         
+      );                                                                                                                                                                                
+
+      setPostResult({ sent: payload, received: result });                                                                                                                               
+    } catch (e) {                       
+      setPostError(e instanceof Error ? e.message : String(e));                                                                                                                         
+    } finally {                                                                                                                                                                         
+      setPostLoading(false);            
+    }                                                                                                                                                                                   
+  }
+  
   const savedPercent = meta.jsonSize > 0                                                                             
     ? ((1 - meta.protobufSize / meta.jsonSize) * 100).toFixed(1)
     : '0';
@@ -157,7 +189,7 @@ function App() {
               {savedPercent}% 작음
             </div>
             <div style={{ fontSize: '13px', opacity: 0.8 }}>
-              {data.users.length}명 기준 |{' '}
+              단일 객체 기준 |{' '}
               {formatBytes(meta.jsonSize - meta.protobufSize)} 절감
             </div>
           </div>
@@ -213,35 +245,93 @@ function App() {
                 color: '#333',
               }}
             >
-              디코딩 검증 (처음 3명)
+              디코딩 검증
             </div>
-            {data.users.slice(0, 3).map((user, i) => (
-              <div
-                key={i}
-                style={{
-                  padding: '12px',
-                  marginBottom: '8px',
-                  borderRadius: '8px',
-                  background: 'white',
-                  border: '1px solid #eee',
-                  textAlign: 'left',
-                  fontSize: '14px',
-                }}
-              >
-                <strong>{user.name}</strong>
-                <span style={{ color: '#999', marginLeft: '8px' }}>
-                  {user.id} | {user.email} | {user.age}세
-                </span>
-              </div>
-            ))}
+            <div
+              style={{
+                padding: '12px',
+                marginBottom: '8px',
+                borderRadius: '8px',
+                background: 'white',
+                border: '1px solid #eee',
+                textAlign: 'left',
+                fontSize: '14px',
+              }}
+            >
+              <strong>{data.name}</strong>
+              <span style={{ color: '#999', marginLeft: '8px' }}>
+                {data.id} | {data.email}
+              </span>
+            </div>
             <div style={{ fontSize: '12px', color: '#999', marginTop: '8px' }}>
               백엔드 바이너리 → Protobuf 디코딩 → JS 객체 복원 성공
             </div>
           </div>
         </div>
       )}
+      <div                                                                                                                                                                              
+          style={{                                                                                                                                                                        
+            marginTop: '40px',                                                                                                                                                          
+            padding: '20px',                                                                                                                                                              
+            borderRadius: '12px',                                                                                                                                                       
+            border: '2px solid #aa3bff',      
+            background: '#faf5ff',        
+          }}
+        >                                                                                                                                                                                 
+          <h2 style={{ fontSize: '20px', marginBottom: '12px' }}>
+            Round-trip 테스트 (프론트 → 백엔드)                                                                                                                                           
+          </h2>                                                                                                                                                                           
+          <p style={{ color: '#666', marginBottom: '16px', fontSize: '14px' }}>
+            JS 객체 → 바이너리 인코딩 → POST → 백엔드가 자바 객체로 자동 디코딩 → JSON 응답                                                                                               
+          </p>                                                                                                                                                                            
+
+          <button                                                                                                                                                                         
+            onClick={handlePostTest}                                                                                                                                                      
+            disabled={postLoading}
+            style={{                                                                                                                                                                      
+              padding: '12px 24px',                                                                                                                                                     
+              background: postLoading ? '#ccc' : '#aa3bff',
+              color: 'white',                                                                                                                                                             
+              border: 'none',                 
+              borderRadius: '8px',                                                                                                                                                        
+              cursor: postLoading ? 'wait' : 'pointer',                                                                                                                                 
+              fontWeight: 'bold',                                                                                                                                                         
+            }}                                
+          >                                                                                                                                                                               
+            {postLoading ? '전송 중...' : '바이너리로 POST 보내기'}                                                                                                                     
+          </button>                                                                                                                                                                       
+
+          {postError && (                                                                                                                                                                 
+            <div style={{ marginTop: '16px', color: '#c92a2a' }}>                                                                                                                       
+              에러: {postError}                                                                                                                                                           
+            </div>                        
+          )}                                                                                                                                                                              
+
+          {postResult && (
+            <div style={{ marginTop: '20px', display: 'grid', gap: '12px' }}>                                                                                                             
+              <div>                                                                                                                                                                     
+                <strong>보낸 객체:</strong>
+                <pre style={{ background: '#1e1e2e', color: '#a6e3a1', padding: '12px', borderRadius: '6px' }}>
+                  {JSON.stringify(postResult.sent, null, 2)}                                                                                                                              
+                </pre>                        
+              </div>                                                                                                                                                                      
+              <div>                                                                                                                                                                       
+                <strong>백엔드가 돌려준 JSON:</strong>                                                                                                                                    
+                <pre style={{ background: '#1e1e2e', color: '#a6e3a1', padding: '12px', borderRadius: '6px' }}>                                                                           
+                  {JSON.stringify(postResult.received.data, null, 2)}                                                                                                                     
+                </pre>                                                                                                                                                                  
+              </div>                                                                                                                                                                      
+              <div style={{ fontSize: '14px', color: '#444' }}>                                                                                                                           
+                업로드 바이너리 크기: <strong>{postResult.received.meta.protobufSize} bytes</strong>                                                                                      
+                {' / '}                                                                                                                                                                   
+                같은 데이터의 JSON 크기: <strong>{postResult.received.meta.jsonSize} bytes</strong>                                                                                       
+              </div>                                                                                                                                                                    
+            </div>                                                                                                                                                                        
+          )}                                                                                                                                                                              
+        </div>
     </div>
   );
+  
 }
 
 export default App;

--- a/jinary-front/src/core/jinary.ts
+++ b/jinary-front/src/core/jinary.ts
@@ -25,7 +25,7 @@ function create(config: JinaryConfig) {
                 timeoutId = setTimeout(() => controller.abort(), config.timeout);
             }
             const mergedHeaders = {                                                                                
-                Accept: 'application/x-protobuf',                                                                  
+                Accept: 'application/x-jinary',                                                                  
                 ...config.headers,                                                                               
             };
             const response = await fetch(fullURL, {
@@ -68,7 +68,7 @@ async function get<T>(
     decodeFunction: (binary: Uint8Array) => T
   ): Promise<JinaryResponse<T>> {                                                                                                          
     const response = await fetch(url, {
-        headers: { Accept: 'application/x-protobuf' },
+        headers: { Accept: 'application/x-jinary' },
       });
 
       if (!response.ok) {

--- a/jinary-front/src/core/jinary.ts
+++ b/jinary-front/src/core/jinary.ts
@@ -101,5 +101,41 @@ async function get<T>(
       };
   } 
 
-export const jinary = { create, get };
+async function post<T>(
+    url: string,
+    binary: Uint8Array,
+): Promise<JinaryResponse<T>> {
+    const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/x-jinary',
+            Accept: 'application/json',
+        },
+        body: binary as BodyInit,
+    });
+
+    if(!response.ok) {
+        throw new Error(
+            `서버 응답 오류: ${response.status} ${response.statusText}`,
+        );
+
+    }
+    const json = (await response.json()) as T;
+
+    const protobufSize = binary.byteLength;
+    const jsonSize = new TextEncoder().encode(JSON.stringify(json)).byteLength;                                                                                                         
+                                                                                                                                                                                        
+    return {                            
+        data: json,                                                                                                                                                                     
+        meta: {                                                                                                                                                                         
+            protobufSize,
+            jsonSize,                                                                                                                                                                   
+            rawHex: Array.from(binary.slice(0, 50))                                                                                                                                   
+                .map((b) => b.toString(16).padStart(2, '0'))
+                .join(' '),             
+        },
+    }; 
+}
+
+export const jinary = { create, get, post };
 export type { JinaryMeta, JinaryResponse };

--- a/jinary-front/src/proto/user_payload.js
+++ b/jinary-front/src/proto/user_payload.js
@@ -1,0 +1,549 @@
+export function encodeUserPayload(message) {
+  let bb = popByteBuffer();
+  _encodeUserPayload(message, bb);
+  return toUint8Array(bb);
+}
+
+function _encodeUserPayload(message, bb) {
+  // optional int32 id = 1;
+  let $id = message.id;
+  if ($id !== undefined) {
+    writeVarint32(bb, 8);
+    writeVarint64(bb, intToLong($id));
+  }
+
+  // optional string name = 2;
+  let $name = message.name;
+  if ($name !== undefined) {
+    writeVarint32(bb, 18);
+    writeString(bb, $name);
+  }
+
+  // optional string email = 3;
+  let $email = message.email;
+  if ($email !== undefined) {
+    writeVarint32(bb, 26);
+    writeString(bb, $email);
+  }
+}
+
+export function decodeUserPayload(binary) {
+  return _decodeUserPayload(wrapByteBuffer(binary));
+}
+
+function _decodeUserPayload(bb) {
+  let message = {};
+
+  end_of_message: while (!isAtEnd(bb)) {
+    let tag = readVarint32(bb);
+
+    switch (tag >>> 3) {
+      case 0:
+        break end_of_message;
+
+      // optional int32 id = 1;
+      case 1: {
+        message.id = readVarint32(bb);
+        break;
+      }
+
+      // optional string name = 2;
+      case 2: {
+        message.name = readString(bb, readVarint32(bb));
+        break;
+      }
+
+      // optional string email = 3;
+      case 3: {
+        message.email = readString(bb, readVarint32(bb));
+        break;
+      }
+
+      default:
+        skipUnknownField(bb, tag & 7);
+    }
+  }
+
+  return message;
+}
+
+function pushTemporaryLength(bb) {
+  let length = readVarint32(bb);
+  let limit = bb.limit;
+  bb.limit = bb.offset + length;
+  return limit;
+}
+
+function skipUnknownField(bb, type) {
+  switch (type) {
+    case 0: while (readByte(bb) & 0x80) { } break;
+    case 2: skip(bb, readVarint32(bb)); break;
+    case 5: skip(bb, 4); break;
+    case 1: skip(bb, 8); break;
+    default: throw new Error("Unimplemented type: " + type);
+  }
+}
+
+function stringToLong(value) {
+  return {
+    low: value.charCodeAt(0) | (value.charCodeAt(1) << 16),
+    high: value.charCodeAt(2) | (value.charCodeAt(3) << 16),
+    unsigned: false,
+  };
+}
+
+function longToString(value) {
+  let low = value.low;
+  let high = value.high;
+  return String.fromCharCode(
+    low & 0xFFFF,
+    low >>> 16,
+    high & 0xFFFF,
+    high >>> 16);
+}
+
+// The code below was modified from https://github.com/protobufjs/bytebuffer.js
+// which is under the Apache License 2.0.
+
+let f32 = new Float32Array(1);
+let f32_u8 = new Uint8Array(f32.buffer);
+
+let f64 = new Float64Array(1);
+let f64_u8 = new Uint8Array(f64.buffer);
+
+function intToLong(value) {
+  value |= 0;
+  return {
+    low: value,
+    high: value >> 31,
+    unsigned: value >= 0,
+  };
+}
+
+let bbStack = [];
+
+function popByteBuffer() {
+  const bb = bbStack.pop();
+  if (!bb) return { bytes: new Uint8Array(64), offset: 0, limit: 0 };
+  bb.offset = bb.limit = 0;
+  return bb;
+}
+
+function pushByteBuffer(bb) {
+  bbStack.push(bb);
+}
+
+function wrapByteBuffer(bytes) {
+  return { bytes, offset: 0, limit: bytes.length };
+}
+
+function toUint8Array(bb) {
+  let bytes = bb.bytes;
+  let limit = bb.limit;
+  return bytes.length === limit ? bytes : bytes.subarray(0, limit);
+}
+
+function skip(bb, offset) {
+  if (bb.offset + offset > bb.limit) {
+    throw new Error('Skip past limit');
+  }
+  bb.offset += offset;
+}
+
+function isAtEnd(bb) {
+  return bb.offset >= bb.limit;
+}
+
+function grow(bb, count) {
+  let bytes = bb.bytes;
+  let offset = bb.offset;
+  let limit = bb.limit;
+  let finalOffset = offset + count;
+  if (finalOffset > bytes.length) {
+    let newBytes = new Uint8Array(finalOffset * 2);
+    newBytes.set(bytes);
+    bb.bytes = newBytes;
+  }
+  bb.offset = finalOffset;
+  if (finalOffset > limit) {
+    bb.limit = finalOffset;
+  }
+  return offset;
+}
+
+function advance(bb, count) {
+  let offset = bb.offset;
+  if (offset + count > bb.limit) {
+    throw new Error('Read past limit');
+  }
+  bb.offset += count;
+  return offset;
+}
+
+function readBytes(bb, count) {
+  let offset = advance(bb, count);
+  return bb.bytes.subarray(offset, offset + count);
+}
+
+function writeBytes(bb, buffer) {
+  let offset = grow(bb, buffer.length);
+  bb.bytes.set(buffer, offset);
+}
+
+function readString(bb, count) {
+  // Sadly a hand-coded UTF8 decoder is much faster than subarray+TextDecoder in V8
+  let offset = advance(bb, count);
+  let fromCharCode = String.fromCharCode;
+  let bytes = bb.bytes;
+  let invalid = '\uFFFD';
+  let text = '';
+
+  for (let i = 0; i < count; i++) {
+    let c1 = bytes[i + offset], c2, c3, c4, c;
+
+    // 1 byte
+    if ((c1 & 0x80) === 0) {
+      text += fromCharCode(c1);
+    }
+
+    // 2 bytes
+    else if ((c1 & 0xE0) === 0xC0) {
+      if (i + 1 >= count) text += invalid;
+      else {
+        c2 = bytes[i + offset + 1];
+        if ((c2 & 0xC0) !== 0x80) text += invalid;
+        else {
+          c = ((c1 & 0x1F) << 6) | (c2 & 0x3F);
+          if (c < 0x80) text += invalid;
+          else {
+            text += fromCharCode(c);
+            i++;
+          }
+        }
+      }
+    }
+
+    // 3 bytes
+    else if ((c1 & 0xF0) == 0xE0) {
+      if (i + 2 >= count) text += invalid;
+      else {
+        c2 = bytes[i + offset + 1];
+        c3 = bytes[i + offset + 2];
+        if (((c2 | (c3 << 8)) & 0xC0C0) !== 0x8080) text += invalid;
+        else {
+          c = ((c1 & 0x0F) << 12) | ((c2 & 0x3F) << 6) | (c3 & 0x3F);
+          if (c < 0x0800 || (c >= 0xD800 && c <= 0xDFFF)) text += invalid;
+          else {
+            text += fromCharCode(c);
+            i += 2;
+          }
+        }
+      }
+    }
+
+    // 4 bytes
+    else if ((c1 & 0xF8) == 0xF0) {
+      if (i + 3 >= count) text += invalid;
+      else {
+        c2 = bytes[i + offset + 1];
+        c3 = bytes[i + offset + 2];
+        c4 = bytes[i + offset + 3];
+        if (((c2 | (c3 << 8) | (c4 << 16)) & 0xC0C0C0) !== 0x808080) text += invalid;
+        else {
+          c = ((c1 & 0x07) << 0x12) | ((c2 & 0x3F) << 0x0C) | ((c3 & 0x3F) << 0x06) | (c4 & 0x3F);
+          if (c < 0x10000 || c > 0x10FFFF) text += invalid;
+          else {
+            c -= 0x10000;
+            text += fromCharCode((c >> 10) + 0xD800, (c & 0x3FF) + 0xDC00);
+            i += 3;
+          }
+        }
+      }
+    }
+
+    else text += invalid;
+  }
+
+  return text;
+}
+
+function writeString(bb, text) {
+  // Sadly a hand-coded UTF8 encoder is much faster than TextEncoder+set in V8
+  let n = text.length;
+  let byteCount = 0;
+
+  // Write the byte count first
+  for (let i = 0; i < n; i++) {
+    let c = text.charCodeAt(i);
+    if (c >= 0xD800 && c <= 0xDBFF && i + 1 < n) {
+      c = (c << 10) + text.charCodeAt(++i) - 0x35FDC00;
+    }
+    byteCount += c < 0x80 ? 1 : c < 0x800 ? 2 : c < 0x10000 ? 3 : 4;
+  }
+  writeVarint32(bb, byteCount);
+
+  let offset = grow(bb, byteCount);
+  let bytes = bb.bytes;
+
+  // Then write the bytes
+  for (let i = 0; i < n; i++) {
+    let c = text.charCodeAt(i);
+    if (c >= 0xD800 && c <= 0xDBFF && i + 1 < n) {
+      c = (c << 10) + text.charCodeAt(++i) - 0x35FDC00;
+    }
+    if (c < 0x80) {
+      bytes[offset++] = c;
+    } else {
+      if (c < 0x800) {
+        bytes[offset++] = ((c >> 6) & 0x1F) | 0xC0;
+      } else {
+        if (c < 0x10000) {
+          bytes[offset++] = ((c >> 12) & 0x0F) | 0xE0;
+        } else {
+          bytes[offset++] = ((c >> 18) & 0x07) | 0xF0;
+          bytes[offset++] = ((c >> 12) & 0x3F) | 0x80;
+        }
+        bytes[offset++] = ((c >> 6) & 0x3F) | 0x80;
+      }
+      bytes[offset++] = (c & 0x3F) | 0x80;
+    }
+  }
+}
+
+function writeByteBuffer(bb, buffer) {
+  let offset = grow(bb, buffer.limit);
+  let from = bb.bytes;
+  let to = buffer.bytes;
+
+  // This for loop is much faster than subarray+set on V8
+  for (let i = 0, n = buffer.limit; i < n; i++) {
+    from[i + offset] = to[i];
+  }
+}
+
+function readByte(bb) {
+  return bb.bytes[advance(bb, 1)];
+}
+
+function writeByte(bb, value) {
+  let offset = grow(bb, 1);
+  bb.bytes[offset] = value;
+}
+
+function readFloat(bb) {
+  let offset = advance(bb, 4);
+  let bytes = bb.bytes;
+
+  // Manual copying is much faster than subarray+set in V8
+  f32_u8[0] = bytes[offset++];
+  f32_u8[1] = bytes[offset++];
+  f32_u8[2] = bytes[offset++];
+  f32_u8[3] = bytes[offset++];
+  return f32[0];
+}
+
+function writeFloat(bb, value) {
+  let offset = grow(bb, 4);
+  let bytes = bb.bytes;
+  f32[0] = value;
+
+  // Manual copying is much faster than subarray+set in V8
+  bytes[offset++] = f32_u8[0];
+  bytes[offset++] = f32_u8[1];
+  bytes[offset++] = f32_u8[2];
+  bytes[offset++] = f32_u8[3];
+}
+
+function readDouble(bb) {
+  let offset = advance(bb, 8);
+  let bytes = bb.bytes;
+
+  // Manual copying is much faster than subarray+set in V8
+  f64_u8[0] = bytes[offset++];
+  f64_u8[1] = bytes[offset++];
+  f64_u8[2] = bytes[offset++];
+  f64_u8[3] = bytes[offset++];
+  f64_u8[4] = bytes[offset++];
+  f64_u8[5] = bytes[offset++];
+  f64_u8[6] = bytes[offset++];
+  f64_u8[7] = bytes[offset++];
+  return f64[0];
+}
+
+function writeDouble(bb, value) {
+  let offset = grow(bb, 8);
+  let bytes = bb.bytes;
+  f64[0] = value;
+
+  // Manual copying is much faster than subarray+set in V8
+  bytes[offset++] = f64_u8[0];
+  bytes[offset++] = f64_u8[1];
+  bytes[offset++] = f64_u8[2];
+  bytes[offset++] = f64_u8[3];
+  bytes[offset++] = f64_u8[4];
+  bytes[offset++] = f64_u8[5];
+  bytes[offset++] = f64_u8[6];
+  bytes[offset++] = f64_u8[7];
+}
+
+function readInt32(bb) {
+  let offset = advance(bb, 4);
+  let bytes = bb.bytes;
+  return (
+    bytes[offset] |
+    (bytes[offset + 1] << 8) |
+    (bytes[offset + 2] << 16) |
+    (bytes[offset + 3] << 24)
+  );
+}
+
+function writeInt32(bb, value) {
+  let offset = grow(bb, 4);
+  let bytes = bb.bytes;
+  bytes[offset] = value;
+  bytes[offset + 1] = value >> 8;
+  bytes[offset + 2] = value >> 16;
+  bytes[offset + 3] = value >> 24;
+}
+
+function readInt64(bb, unsigned) {
+  return {
+    low: readInt32(bb),
+    high: readInt32(bb),
+    unsigned,
+  };
+}
+
+function writeInt64(bb, value) {
+  writeInt32(bb, value.low);
+  writeInt32(bb, value.high);
+}
+
+function readVarint32(bb) {
+  let c = 0;
+  let value = 0;
+  let b;
+  do {
+    b = readByte(bb);
+    if (c < 32) value |= (b & 0x7F) << c;
+    c += 7;
+  } while (b & 0x80);
+  return value;
+}
+
+function writeVarint32(bb, value) {
+  value >>>= 0;
+  while (value >= 0x80) {
+    writeByte(bb, (value & 0x7f) | 0x80);
+    value >>>= 7;
+  }
+  writeByte(bb, value);
+}
+
+function readVarint64(bb, unsigned) {
+  let part0 = 0;
+  let part1 = 0;
+  let part2 = 0;
+  let b;
+
+  b = readByte(bb); part0 = (b & 0x7F); if (b & 0x80) {
+    b = readByte(bb); part0 |= (b & 0x7F) << 7; if (b & 0x80) {
+      b = readByte(bb); part0 |= (b & 0x7F) << 14; if (b & 0x80) {
+        b = readByte(bb); part0 |= (b & 0x7F) << 21; if (b & 0x80) {
+
+          b = readByte(bb); part1 = (b & 0x7F); if (b & 0x80) {
+            b = readByte(bb); part1 |= (b & 0x7F) << 7; if (b & 0x80) {
+              b = readByte(bb); part1 |= (b & 0x7F) << 14; if (b & 0x80) {
+                b = readByte(bb); part1 |= (b & 0x7F) << 21; if (b & 0x80) {
+
+                  b = readByte(bb); part2 = (b & 0x7F); if (b & 0x80) {
+                    b = readByte(bb); part2 |= (b & 0x7F) << 7;
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return {
+    low: part0 | (part1 << 28),
+    high: (part1 >>> 4) | (part2 << 24),
+    unsigned,
+  };
+}
+
+function writeVarint64(bb, value) {
+  let part0 = value.low >>> 0;
+  let part1 = ((value.low >>> 28) | (value.high << 4)) >>> 0;
+  let part2 = value.high >>> 24;
+
+  // ref: src/google/protobuf/io/coded_stream.cc
+  let size =
+    part2 === 0 ?
+      part1 === 0 ?
+        part0 < 1 << 14 ?
+          part0 < 1 << 7 ? 1 : 2 :
+          part0 < 1 << 21 ? 3 : 4 :
+        part1 < 1 << 14 ?
+          part1 < 1 << 7 ? 5 : 6 :
+          part1 < 1 << 21 ? 7 : 8 :
+      part2 < 1 << 7 ? 9 : 10;
+
+  let offset = grow(bb, size);
+  let bytes = bb.bytes;
+
+  switch (size) {
+    case 10: bytes[offset + 9] = (part2 >>> 7) & 0x01;
+    case 9: bytes[offset + 8] = size !== 9 ? part2 | 0x80 : part2 & 0x7F;
+    case 8: bytes[offset + 7] = size !== 8 ? (part1 >>> 21) | 0x80 : (part1 >>> 21) & 0x7F;
+    case 7: bytes[offset + 6] = size !== 7 ? (part1 >>> 14) | 0x80 : (part1 >>> 14) & 0x7F;
+    case 6: bytes[offset + 5] = size !== 6 ? (part1 >>> 7) | 0x80 : (part1 >>> 7) & 0x7F;
+    case 5: bytes[offset + 4] = size !== 5 ? part1 | 0x80 : part1 & 0x7F;
+    case 4: bytes[offset + 3] = size !== 4 ? (part0 >>> 21) | 0x80 : (part0 >>> 21) & 0x7F;
+    case 3: bytes[offset + 2] = size !== 3 ? (part0 >>> 14) | 0x80 : (part0 >>> 14) & 0x7F;
+    case 2: bytes[offset + 1] = size !== 2 ? (part0 >>> 7) | 0x80 : (part0 >>> 7) & 0x7F;
+    case 1: bytes[offset] = size !== 1 ? part0 | 0x80 : part0 & 0x7F;
+  }
+}
+
+function readVarint32ZigZag(bb) {
+  let value = readVarint32(bb);
+
+  // ref: src/google/protobuf/wire_format_lite.h
+  return (value >>> 1) ^ -(value & 1);
+}
+
+function writeVarint32ZigZag(bb, value) {
+  // ref: src/google/protobuf/wire_format_lite.h
+  writeVarint32(bb, (value << 1) ^ (value >> 31));
+}
+
+function readVarint64ZigZag(bb) {
+  let value = readVarint64(bb, /* unsigned */ false);
+  let low = value.low;
+  let high = value.high;
+  let flip = -(low & 1);
+
+  // ref: src/google/protobuf/wire_format_lite.h
+  return {
+    low: ((low >>> 1) | (high << 31)) ^ flip,
+    high: (high >>> 1) ^ flip,
+    unsigned: false,
+  };
+}
+
+function writeVarint64ZigZag(bb, value) {
+  let low = value.low;
+  let high = value.high;
+  let flip = high >> 31;
+
+  // ref: src/google/protobuf/wire_format_lite.h
+  writeVarint64(bb, {
+    low: (low << 1) ^ flip,
+    high: ((high << 1) | (low >>> 31)) ^ flip,
+    unsigned: false,
+  });
+}

--- a/jinary-front/src/proto/user_payload.proto
+++ b/jinary-front/src/proto/user_payload.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";                                                                                                                                                                      
+                                                                                                                                                                                          
+  message UserPayload {                                                                                                                                                                   
+    int32  id    = 1;                                                                                                                                                                     
+    string name  = 2;                                                                                                                                                                     
+    string email = 3;                                                                                                                                                                     
+  }


### PR DESCRIPTION
지금까지의 데모는 "백엔드 → 프론트" 한 방향뿐이었습니다. 양방향이 되어야
"바이너리 통신 라이브러리"라고 부를 수 있고, 백엔드의 `@Jinary`가 정말
**자바 객체처럼 받지만 와이어는 바이너리**인지를 눈으로 검증해야
다음 단계(자동 스키마 협상)로 갈 명분이 생깁니다.

지금까지는 **다운로드** 절감률만 보여줬는데, **업로드** 방향까지 측정할 수 있게 되었습니다. 

그리고, feat/#11은 실수로 mySelf라고 했는데 withAI 버전입니다. AI 버전이라서, AI와 어떤 대화를 나눴고, 의사결정을 내리는데 도움을 받았는지 md 파일로 정리를 했습니다. 

간단하게 제 말로 요약을 해보자면,
### 1. `UserPayload.proto` 스키마 + 번들 생성                                                                                                                                           
  - 백엔드 `JinarySchemaGenerator`가 자동 생성하는 스키마와 1:1 매칭되는 .proto 정의
  - `package.json`에 `proto:gen:payload` 스크립트 추가                                                                                                                                    
  - 결과물: `encodeUserPayload` / `decodeUserPayload` 함수 확보                                                                                                                           
                                                                                                                                                                                          
  ### 2. `core/jinary.ts`에 `post()` 추가                                                                                                                                                 
  - `Content-Type: application/x-jinary` / `Accept: application/json` 으로 바이너리 POST → JSON 응답                                                                                      
  - 업로드 방향 사이즈 메타데이터(protobuf vs JSON) 자동 측정                                                                                                                             
                                                                                                                                                                                          
  ### 3. App.jsx — Round-trip 데모 + GET 마이그레이션                                                                                                                                     
  - POST 데모 영역 신설: JS 객체 → 바이너리 인코딩 → POST → JSON 응답 비교 UI                                                                                                             
  - GET 호출을 `BACKEND_URL + '/test/binary'` + `decodeUserPayload`로 변경                                                                                                                
  - 단일 `UserPayload` 응답 모양에 맞춰 렌더링 정리                                                                                                                                       
                                                                                                                                                                                          
  ## 부수 변경                                                                                                                                                                            
  - `core/jinary.ts`의 `Accept` 헤더를 `application/x-protobuf` → `application/x-jinary` 로 교체 (백엔드 새 미디어 타입에 맞춤)                                                           
  - `.env` 의 `VITE_BACKEND_URL`을 origin만 남기는 형태로 정리                                                                                                                            
                                                                                                                                                                                          
  ## 검증                                                                                                                                                                                 
  - 백엔드 로컬 실행 후 GET/POST 버튼 모두 정상 동작 확인                                                                                                                                 
  - POST round-trip: 보낸 객체와 백엔드 응답 JSON이 무손실 일치                                                                                                                           
  - 상세 의사결정/디버깅 과정: `jinary-front/docs/front-jinaryPost.md`
<img width="879" height="692" alt="스크린샷 2026-05-04 오전 12 13 22" src="https://github.com/user-attachments/assets/a078a320-b221-4ac9-b37d-11afbac07d27" />
<img width="879" height="692" alt="스크린샷 2026-05-04 오전 12 13 22" src="https://github.com/user-attachments/assets/a078a320-b221-4ac9-b37d-11afbac07d27" />

closes #14 